### PR TITLE
Fix Andrew's taproot proof link

### DIFF
--- a/bib_short.bib
+++ b/bib_short.bib
@@ -1,7 +1,7 @@
 @misc{poelstra-taproot,
     title={{Taproot Security Proof}},
     author={Andrew Poelstra},
-    howpublished={\url{https://https://github.com/apoelstra/taproot}},
+    howpublished={\url{https://github.com/apoelstra/taproot}},
     year={2018}
 }
 


### PR DESCRIPTION
You accidentally had `https://` prefix twice :)